### PR TITLE
Render objective 'what' field as markdown

### DIFF
--- a/application/templates/_macros.html
+++ b/application/templates/_macros.html
@@ -32,7 +32,7 @@
         Competency: <a href="">{{ link.name }}</a>
 
       {%- elif link.entry_type == 'objective' -%}
-        Objective: <a href="">{{ link.entry.what|truncate(40) }}</a>
+        Objective: <a href="">{{ link.entry.what|truncate(40)|markdown }}</a>
 
       {%- elif link.entry_type == 'feedback' -%}
         Feedback: <a href="">{{ link.entry.details|truncate(40) }}</a>

--- a/application/templates/competency/view-competency.html
+++ b/application/templates/competency/view-competency.html
@@ -96,7 +96,7 @@
       <label class="form-label">Objectives</label>
       <select id="objectives" name="objectives" class="form-control">
         {% for objective in current_user.objectives %}
-        <option value="{{ objective.id }}">{{ objective.entry.what|truncate(40) }}</option>
+        <option value="{{ objective.id }}">{{ objective.entry.what|truncate(40)|markdown }}</option>
         {% endfor %}
       </select>
       <button>add</button>

--- a/application/templates/feedback/give-feedback.html
+++ b/application/templates/feedback/give-feedback.html
@@ -62,7 +62,7 @@
            <ul>
               {% for objective in feedback_request.requested_by.objectives.objectives %}
                 <li class="objective">
-                  <header class="objective-header">{{objective.what}} <span class="toggle"><a href="#">Show</a><a href="#" style="display: none;">Hide</a></span></header>
+                  <header class="objective-header">{{objective.what|markdown}} <span class="toggle"><a href="#">Show</a><a href="#" style="display: none;">Hide</a></span></header>
                   <div class="details" style="display: none;">
                     {{objective.how|markdown}}
                   </div>

--- a/application/templates/feedback/view-feedback.html
+++ b/application/templates/feedback/view-feedback.html
@@ -48,7 +48,7 @@
           <ul>
             {% for objective in feedback_request.requested_by.objectives.objectives %}
               <li class="objective">
-                <header class="objective-header">{{objective.what}} <span class="toggle"><a href="#">Show</a><a href="#" style="display: none;">Hide</a></span></header>
+                <header class="objective-header">{{objective.what|markdown}} <span class="toggle"><a href="#">Show</a><a href="#" style="display: none;">Hide</a></span></header>
                 <div class="details" style="display: none;">
                   {{objective.how|markdown}}
                 </div>

--- a/application/templates/mylog/entry.html
+++ b/application/templates/mylog/entry.html
@@ -43,7 +43,7 @@
         {%- if link.__class__.__name__ == 'Competency' -%}
           Competency: {{ link.name }}
         {%- elif link.entry_type == 'objective' -%}
-          Objective: {{ link.entry.what }}
+          Objective: {{ link.entry.what|markdown }}
         {%- endif %}
         <a href="remove-link?link={{ link.id }}">remove</a>
       </li>

--- a/application/templates/notes/_link_note_with.html
+++ b/application/templates/notes/_link_note_with.html
@@ -20,7 +20,7 @@
     <label class="form-label">Objectives</label>
     <select id="objectives" name="objectives" class="form-control">
       {% for objective in current_user.objectives %}
-      <option value="{{ objective.id }}">{{ objective.entry.what|truncate(40) }}</option>
+      <option value="{{ objective.id }}">{{ objective.entry.what|truncate(40)|markdown }}</option>
       {% endfor %}
     </select>
     <button>add</button>

--- a/application/templates/notes/recent-notes.html
+++ b/application/templates/notes/recent-notes.html
@@ -37,7 +37,7 @@
         {%- if link.__class__.__name__ == 'Competency' -%}
           Competency: <a href="/">{{ link.name }}</a>
         {%- elif link.entry_type == 'objective' -%}
-          Objective: <a href="/">{{ link.entry.what }}</a>
+          Objective: <a href="/">{{ link.entry.what|truncate(40)|markdown }}</a>
         {%- endif %}
         <span class="remove-link"><a href="remove-link?link={{ link.id }}">remove</a></span>
       </li>

--- a/application/templates/objectives/base.html
+++ b/application/templates/objectives/base.html
@@ -9,7 +9,8 @@
     </h2>
     <ul class="content-nav-list">
       {% for obj in objectives %}
-        <li><a {% if objective and objective.id == obj.id %}class="current"{% endif %} href="{{url_for('objectives.view_objective', id=obj.id)}}">{{obj.entry.what|truncate(35, True)}}</a></li>
+        <li><a {% if objective and objective.id == obj.id %}class="current"{%
+          endif %} href="{{url_for('objectives.view_objective', id=obj.id)}}">{{obj.entry.what|truncate(40)|markdown }}</a></li>
       {% endfor %}
     </ul>
     <div class="content-nav-action"><a href="{{url_for('objectives.add_objective')}}">+ add objective</a></div>

--- a/application/templates/objectives/objective-view.html
+++ b/application/templates/objectives/objective-view.html
@@ -5,7 +5,7 @@
   <h1 class="heading-large">Objective</h1><!-- to be title in future -->
 
   <h3 class="heading-small">What</h3>
-  <div>{{objective.entry.what}}</div>
+  <div>{{objective.entry.what|markdown}}</div>
 
   <h3 class="heading-small">How</h3>
   <div class="rendered-markdown">{{objective.entry.how|markdown}}</div>

--- a/application/templates/objectives/objectives.html
+++ b/application/templates/objectives/objectives.html
@@ -28,7 +28,7 @@
       <ul>
         {% for objective in objectives %}
           <li class="objective">
-            <header class="objective-header">{{objective.entry.what}} <span class="toggle"><a href="#">Show</a><a href="#" style="display: none;">Hide</a></span></header>
+            <header class="objective-header">{{objective.entry.what|markdown}} <span class="toggle"><a href="#">Show</a><a href="#" style="display: none;">Hide</a></span></header>
             <div class="details" style="display: none;">
               {{objective.entry.how|markdown}}
               <a href="{{url_for('objectives.edit_objective', id=objective.id)}}">Edit</a>


### PR DESCRIPTION
NOTE - this messes up the layout of some parts of the site, eg the "Linked with" section, due to newlines and paragraph tags.

This will be negated by adding titles to objectives and listing those instead.
