### PR TITLE
Add progress field to objectives

### DIFF
--- a/application/models.py
+++ b/application/models.py
@@ -103,14 +103,23 @@ class Tag(db.Document):
     name = db.StringField()
 
 
-schemas = {'objective': ('how', 'what', 'started_on', 'due_by', 'title'),
-           'feedback': ('template', 'requested_from', 'requested_by',
-                        'requested_from_name', 'requested_by_name',
-                        'details', 'share_objectives', 'objectives',
-                        'sent', 'replied'),
-           'comment': ('content',),
-           'evidence': ('content', 'title'),
-           'log': ('content', 'title')}
+schemas = {
+    'objective': ('how', 'what', 'started_on', 'due_by', 'title', 'progress'),
+    'feedback': (
+        'template',
+        'requested_from',
+        'requested_by',
+        'requested_from_name',
+        'requested_by_name',
+        'details',
+        'share_objectives',
+        'objectives',
+        'sent',
+        'replied'),
+    'comment': ('content',),
+    'evidence': ('content', 'title'),
+    'log': ('content', 'title')
+}
 
 
 class Entry(db.DynamicDocument):

--- a/application/objectives/forms.py
+++ b/application/objectives/forms.py
@@ -1,11 +1,10 @@
 import datetime
 
-from flask.ext.login import current_user
 from flask.ext.wtf import Form
 from wtforms.validators import DataRequired, Required
 from wtforms.fields import StringField, TextAreaField
 
-from application.models import Entry, LogEntry
+from application.models import create_log_entry
 from application.utils import a_year_from_now
 
 
@@ -13,28 +12,24 @@ class ObjectiveForm(Form):
     title = StringField('Title', validators=[Required()])
     what = TextAreaField('What is your objective?', validators=[Required()])
     how = TextAreaField('How will you achieve this?', validators=[Required()])
+    progress = TextAreaField('What progress have you made?')
 
     def update(self, objective):
         objective.entry.update(
             title=self.title.data,
             what=self.what.data,
+            progress=self.progress.data,
             how=self.how.data)
-        objective.entry.save()
 
     def create(self):
-        entry = Entry(
+        objective = create_log_entry(
+            'objective',
             title=self.title.data,
             what=self.what.data,
             how=self.how.data,
+            progress=self.progress.data,
             started_on=datetime.datetime.utcnow(),
             due_by=a_year_from_now())
-        entry.save()
-
-        objective = LogEntry(
-            entry_type='objective',
-            owner=current_user._get_current_object(),
-            entry=entry)
-        objective.save()
 
         objective.add_tag('Objective')
 

--- a/application/objectives/views.py
+++ b/application/objectives/views.py
@@ -89,6 +89,8 @@ def edit(id=None):
     if objective:
         form.what.data = objective.entry.what
         form.how.data = objective.entry.how
+        if 'progress' in objective.entry:
+            form.progress.data = objective.entry.progress
 
     return render_template(
         'objectives/edit.html',

--- a/application/templates/objectives/edit.html
+++ b/application/templates/objectives/edit.html
@@ -35,6 +35,16 @@
       </div>
     </div>
 
+    <div class="grid-row">
+      <div class="column-half">
+        {{ render_field(form.progress, rows=10) }}
+      </div>
+      <div class="column-half">
+        <h2 class="heading-medium guidance-heading">Progress</h2>
+        <p>What progress have you made towards achieving this objective?</p>
+      </div>
+    </div>
+
     <div class="form-group">
       <button class="button">
         {%- if objective -%}

--- a/application/templates/objectives/view.html
+++ b/application/templates/objectives/view.html
@@ -36,9 +36,9 @@
       <h3 class="heading-small">How</h3>
       <div class="rendered-markdown">{{ objective.entry.how|markdown }}</div>
 
-      <h3 class="heading-small">Progress</h3>
-      <div class="rendered-markdown"></div>
-    </section>
+    <h3 class="heading-small">Progress</h3>
+    <div class="rendered-markdown">{{ objective.entry.progress|default('')|markdown }}</div>
+  </section>
 
     <section class="obj_attachments">
       <h3 class="heading-small">Evidence</h3>


### PR DESCRIPTION
- Adds a new Evidence section to the Objective page
- User can Add Evidence, using a button on the page
- Or they can promote an existing linked Note
- User can remove evidence - this deletes the evidence from the database
