### PR TITLE
Fix linking competencies and objectives to notes

### DIFF
--- a/application/competency/forms.py
+++ b/application/competency/forms.py
@@ -1,18 +1,26 @@
 from flask.ext.login import current_user
 from flask.ext.wtf import Form
-from wtforms.fields import SelectField
+from wtforms.fields import SelectMultipleField
+
+from application.competency.models import Competency
 
 
-def make_link_form(**enable):
-    form = Form()
+def make_link_form(**kwargs):
+    form = kwargs.pop('form', Form)
     user = current_user._get_current_object()
 
     def choices(items):
         return [(str(item.id), str(item)) for item in items]
 
     for linktype in ['competencies', 'notes', 'objectives']:
-        if enable.get(linktype, False):
-            setattr(form, linktype, SelectField(
-                choices=choices(getattr(user, linktype))))
+        if kwargs.get(linktype, False):
 
-    return form
+            if linktype == 'competencies':
+                _choices = choices(Competency.objects)
+            else:
+                _choices = choices(getattr(user, linktype))
+
+            setattr(form, linktype, SelectMultipleField(
+                choices=_choices))
+
+    return form()

--- a/application/notes/forms.py
+++ b/application/notes/forms.py
@@ -17,8 +17,7 @@ class NoteForm(Form):
             title=self.title.data,
             content=self.content.data)
 
-        for tag in self.tags.data.split(','):
-            note.add_tag(tag)
+        self.add_tags(note, self.tags.data)
 
     def create(self):
         note = create_log_entry(
@@ -26,7 +25,10 @@ class NoteForm(Form):
             title=self.title.data,
             content=self.content.data)
 
-        for tag in self.tags.data.split(','):
-            note.add_tag(tag)
+        self.add_tags(note, self.tags.data)
 
         return note
+
+    def add_tags(self, note, tags):
+        for tag in self.tags.data.split(','):
+            note.add_tag(tag)

--- a/application/templates/notes/edit.html
+++ b/application/templates/notes/edit.html
@@ -6,6 +6,12 @@
 
 {% from "_macros.html" import render_field, render_hidden %}
 
+{% block content_pane %}
+<form method="POST">
+  {{ super() }}
+</form>
+{% endblock %}
+
 {% block content %}
 
   <h1 class="heading-large">
@@ -17,7 +23,7 @@
     {%- endif -%}
   </h1>
 
-  <form action="" method="POST" class="new-note">
+  <div class="new-note">
     {{ render_hidden(form) }}
 
     <div class="form-group">
@@ -41,7 +47,7 @@
     <div class="form-group">
       <input class="button"  type="submit" value="Save">
     </div>
-  </form>
+  </div>
 
   <div class="panel-indent">
     <p>Don't forget you can also email notes to: <strong class="bold-small"><a href="mailto:{{current_user.inbox_email}}" target="_blank">{{current_user.inbox_email}}</a></strong></p>
@@ -51,8 +57,6 @@
 {% block content_links %}
 
 <h2 class="heading-medium">Link your note</h2>
-
-<form method="post" action="{{ url_for('notes.link', id=note.id|default("add")) }}">
 
 {% macro link_checkbox(item, title, field_name) %}
 <label class="linking-checkbox" for="{{item.id}}_id">
@@ -80,9 +84,6 @@
     {% endfor %}
   </div>
 </section>
-
-<button class="button">Update links</button>
-</form>
 
 {% endblock %}
 


### PR DESCRIPTION
On creating or editing a note, allow linking to competencies and objectives in a single form submission. If updating, allow unlinking by clearing checkboxes.
